### PR TITLE
Invert colors

### DIFF
--- a/src/Parser/Command/SelectBitImageModeCmd.php
+++ b/src/Parser/Command/SelectBitImageModeCmd.php
@@ -71,6 +71,7 @@ class SelectBitImageModeCmd extends EscposCommand implements ImageContainer
         $im -> readImageBlob($pbmBlob, 'pbm');
         $im -> rotateImage('#fff', 90.0);
         $im -> flopImage();
+        $im -> negateImage(true);
         return $im -> getImageBlob();
     }
     


### PR DESCRIPTION
I'm testing [receipt-with-qrcode.bin](https://github.com/gilbertfl/escpos-netprinter/blob/master/receipt-with-qrcode.bin), but I don't know if this is a BUG, ​​or this file has problems with the image

Before 
<img width="215" height="260" alt="image" src="https://github.com/user-attachments/assets/1a79c9b0-a0a6-49fa-8d8d-670ce54948ab" />

After
<img width="215" height="251" alt="image" src="https://github.com/user-attachments/assets/477668bd-b090-4e6b-85a6-e9f3eebbb866" />
